### PR TITLE
Assert build succeeds locally

### DIFF
--- a/components/Main.tsx
+++ b/components/Main.tsx
@@ -7,13 +7,11 @@ import About from './About';
 type Props = {
   deviceDetail: DeviceDetail;
   navOptions: NavOption[];
-  footerOptions: NavOption[];
 };
 
 const Main = ({
   deviceDetail: { type, windowWidth },
   navOptions,
-  footerOptions,
 }: Props): React.ReactElement => {
   const delay: number = 7000;
 
@@ -40,12 +38,6 @@ Main.propTypes = {
     windowWidth: PropTypes.number,
   }),
   navOptions: PropTypes.arrayOf(
-    PropTypes.shape({
-      option: PropTypes.string.isRequired,
-      link: PropTypes.string.isRequired,
-    }).isRequired
-  ),
-  footerOptions: PropTypes.arrayOf(
     PropTypes.shape({
       option: PropTypes.string.isRequired,
       link: PropTypes.string.isRequired,


### PR DESCRIPTION
#### Summary

The build of my application (for production use) failed via Github actions:

<img width="576" alt="Screen Shot 2021-02-20 at 8 19 33 PM" src="https://user-images.githubusercontent.com/12674658/108612688-fa924a00-73b8-11eb-8047-822821837dfa.png">

**Reason:** `Footer` is no longer being rendered  in the `Main` component and `footerOptions` was set up as an expected prop. I removed `footerOptions` from the `Main.propTypes` and the typescript type definition `Props`.

#### Testing

1. Run `yarn build`  and assert that it succeeds. 